### PR TITLE
Added a needed Qt header file to testserver.h

### DIFF
--- a/molequeue/app/testing/testserver.h
+++ b/molequeue/app/testing/testserver.h
@@ -23,6 +23,7 @@
 
 #include <QtGlobal>
 
+#include <QtCore/QDataStream>
 #include <QtCore/QDateTime>
 #include <QtCore/QThread>
 #include <QtCore/QTimer>


### PR DESCRIPTION
Perhaps this is only with more recent versions of Qt,
but the tests wouldn't compile because QDataStream was
not defined. Adding this header file fixed the problem.
