### PR TITLE
GenerateExportHeader: fix compiler version detection

### DIFF
--- a/cmake/GenerateExportHeader.cmake
+++ b/cmake/GenerateExportHeader.cmake
@@ -162,14 +162,14 @@ endmacro()
 macro(_test_compiler_hidden_visibility)
 
   if(CMAKE_COMPILER_IS_GNUCXX)
-    exec_program(${CMAKE_C_COMPILER} ARGS --version
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --version
       OUTPUT_VARIABLE _gcc_version_info)
-    string(REGEX MATCH "[345]\\.[0-9]\\.[0-9]"
+    string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]"
       _gcc_version "${_gcc_version_info}")
     # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
     # patch level, handle this here:
     if(NOT _gcc_version)
-      string(REGEX REPLACE ".*\\(GCC\\).* ([34]\\.[0-9]) .*" "\\1.0"
+      string(REGEX REPLACE ".*\\(GCC\\).* ([3-9]\\.[0-9]) .*" "\\1.0"
         _gcc_version "${_gcc_version_info}")
     endif()
 
@@ -179,7 +179,7 @@ macro(_test_compiler_hidden_visibility)
   endif()
 
   if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
-    exec_program(${CMAKE_CXX_COMPILER} ARGS -V
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -V
       OUTPUT_VARIABLE _intel_version_info)
     string(REGEX REPLACE ".*Version ([0-9]+(\\.[0-9]+)+).*" "\\1"
       _intel_version "${_intel_version_info}")


### PR DESCRIPTION
exec_program is deprecated and there was never an `ARGS` argument
anyways.