### PR TITLE
Add Thread.join() to EventLoop.stop() in python client

### DIFF
--- a/python/molequeue/client.py
+++ b/python/molequeue/client.py
@@ -89,6 +89,7 @@ class EventLoop(Thread):
 
   def stop(self):
     self.io_loop.stop()
+    self.join()
 
 class MoleQueueException(Exception):
   """The base class of all MoleQueue exceptions """


### PR DESCRIPTION
Prevents ZMQError when exiting after disconnecting client.

Note: this is being submitted on the 0.7 branch, but should also be applied the master branch.