### PR TITLE
Rework Qt 5 component finding a little

### DIFF
--- a/molequeue/app/CMakeLists.txt
+++ b/molequeue/app/CMakeLists.txt
@@ -1,8 +1,11 @@
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets Network)
-
-if(MoleQueue_USE_EZHPC_UIT)
-  find_package(Qt5 REQUIRED COMPONENTS XmlPatterns)
+set(_qt_packages Core Widgets Network)
+if(ENABLE_TESTING)
+  list(APPEND _qt_packages Test)
 endif()
+if(MoleQueue_USE_EZHPC_UIT)
+  list(APPEND _qt_packages XmlPatterns)
+endif()
+find_package(Qt5 REQUIRED COMPONENTS ${_qt_packages})
 
 # Provide some simple API to find the plugins, scripts, etc.
 if(APPLE)


### PR DESCRIPTION
Build up our list, and call find_package(Qt5 ...) once, add the Test
module if testing was enabled.