### PR TITLE
build: bump minimum required version of CMake to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(MoleQueue)
 


### PR DESCRIPTION
CMake 4 drops support of <3.5
https://cmake.org/cmake/help/latest/release/4.0.html#id14