### PR TITLE
build!: replace deprecated FindPythonInterp with FindPython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(MoleQueue)
 

--- a/molequeue/app/CMakeLists.txt
+++ b/molequeue/app/CMakeLists.txt
@@ -15,8 +15,7 @@ else()
   set(MoleQueue_LIB_DIR "${INSTALL_LIBRARY_DIR}")
 endif()
 
-# Find a python 2.x interpreter.
-find_package(PythonInterp 2 QUIET)
+find_package(Python QUIET COMPONENTS Interpreter)
 
 include(GenerateExportHeader)
 

--- a/molequeue/app/testing/CMakeLists.txt
+++ b/molequeue/app/testing/CMakeLists.txt
@@ -8,8 +8,8 @@ set(MoleQueue_TESTDATA_DIR
 set(MoleQueue_TESTSCRIPT_DIR
   "${MoleQueue_SOURCE_DIR}/molequeue/app/testing/scripts/")
 set(MoleQueue_TESTEXEC_DIR "${MoleQueue_BINARY_DIR}/bin/")
-if(PYTHON_EXECUTABLE)
-  set(MoleQueue_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+if(Python_EXECUTABLE)
+  set(MoleQueue_PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
 endif()
 configure_file(molequeuetestconfig.h.in molequeuetestconfig.h)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,7 +1,7 @@
-find_package(PythonInterp REQUIRED)
+find_package(Python REQUIRED COMPONENTS Interpreter)
 
-if(PYTHONINTERP_FOUND)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+if(Python_Interpreter_FOUND)
+  execute_process(COMMAND ${Python_EXECUTABLE} -c
     "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
     OUTPUT_VARIABLE PYTHON_PACKAGES_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
FindPythonInterp is deprecated since 3.12
https://cmake.org/cmake/help/v3.12/module/FindPythonInterp.html

close #37